### PR TITLE
Changes for cross-match v0.5

### DIFF
--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -18,7 +18,7 @@ XMatch
 ------
 
 .. automodule:: target_selection.xmatch
-   :members: XMatchModel, XMatchPlanner
+   :members: XMatchModel, XMatchPlanner, RUN_ID_BIT_SHIFT
 
 Skies
 -----

--- a/python/target_selection/__main__.py
+++ b/python/target_selection/__main__.py
@@ -98,9 +98,6 @@ def run(targeting_plan, config_file, overwrite, keep, region, load,
         skip_query, include, exclude, write_table, allow_errors):
     """Runs target selection for all cartons."""
 
-#    carton_classes = {Carton.name: Carton
-#                      for Carton in BaseCarton.__subclasses__()}
-    # find grandchilden Cartons as well
     carton_classes = {Carton.name: Carton
                       for Carton in all_subclasses(BaseCarton)}
 

--- a/python/target_selection/config/xmatch.yml
+++ b/python/target_selection/config/xmatch.yml
@@ -1,418 +1,172 @@
-'0.1.0-alpha.1':
-    order: hierarchical
-    key: resolution
-    query_radius: 1.
-    schema: catalogdb
-    output_table: catalog
-    start_node: tic_v8
-    debug: true
-    log_path: false
-    disable_seqscan: true
-    sample_region:
-        - [270., 66.56, 5.]    # North CVZ
-        - [90., -66.56, 5.]    # South CVZ
-        - [45.0, 0.0, 5.]      # Stripe-82-West
-        - [135.0, 1.0, 5.]     # eFEDS
-        - [315.0, 0.0, 5.]     # Stripe-82-East
-    exclude: null
-    tables:
-        tic_v8:
-            ra_column: ra
-            dec_column: dec
-            pmra_column: pmra
-            pmdec_column: pmdec
-            is_pmra_cos: true
-            parallax_column: plx
-            epoch: 2015.5
-            skip: false
-        gaia_dr2_source:
-            ra_column: ra
-            dec_column: dec
-            pmra_column: pmra
-            pmdec_column: pmdec
-            is_pmra_cos: true
-            parallax_column: parallax
-            epoch: 2015.5
-            skip: true
-        legacy_survey_dr8:
-            ra_column: ra
-            dec_column: dec
-            pmra_column: pmra
-            pmdec_column: pmdec
-            is_pmra_cos: true
-            parallax_column: parallax
-            epoch_column: ref_epoch
-        twomass_psc:
-            ra_column: ra
-            dec_column: decl
-            epoch_column: jdate
-            epoch_format: jd
-            skip: true
-        tycho2:
-            ra_column: ramdeg
-            dec_column: demdeg
-            pmra_column: pmra
-            pmdec_column: pmde
-            is_pmra_cos: true
-            epoch: 2000.0
-        ps1_g18:
-            ra_column: ramean
-            dec_column: decmean
-        catwise:
-            ra_column: ra_pm
-            dec_column: dec_pm
-            pmra_column: pmra
-            pmdec_column: pmdec
-            epoch: 2014.115  # MJD 56700
-            parallax_column: par_pm
-        guvcat:
-            ra_column: ra
-            dec_column: dec
-        sdss_dr13_photoobj:
-            ra_column: ra
-            dec_column: dec
-        kepler_input_10:
-            ra_column: kic_ra
-            dec_column: kic_dec
-        glimpse:
-            ra_column: ra
-            dec_column: dec
-        skymapper_dr1_1:
-            ra_column: raj2000
-            dec_column: dej2000
-        gaia_qso:
-            ra_column: raj2000
-            dec_column: dej2000
-        bhm_csc:
-            ra_column: oir_ra
-            dec_column: oir_dec
-        gaia_dr2_wd_sdss:
-            ra_column: ra
-            dec_column: dec
-        unwise:
-            ra_column: ra
-            dec_column: dec
-
-'0.1.0-alpha.2':
-    base_version: 0.1.0-alpha.1
-    key: row_count
-    log_path: xmatch_{version}.log
-    exclude: ['kepler_input_10']
-    tables:
-        allwise:
-            ra_column: ra
-            dec_column: dec
-            pmra_column: pmra
-            pmdec_column: pmdec
-            epoch: 2010.5589  # MJD 55400.0
-        gaia_dr2_source:
-            join_weight: 0.1
-            skip: True
-        gaia_unwise_agn:
-            join_weight: 0.3
-
-'0.1.0-alpha.3':
-    base_version: 0.1.0-alpha.2
-    order:
-        - tic_v8
-        - legacy_survey_dr8
-        - sdss_dr13_photoobj
-        - skymapper_dr1_1
-        - kepler_input_10
-        - ps1_g18
-        - tycho2
-        - gaia_qso
-        - bhm_csc
-        - gaia_dr2_wd_sdss
-        - guvcat
-        - allwise
-        - unwise
-        - catwise
-        - glimpse
-    key: null
-    exclude: null
-    tables:
-        tic_v8:
-            join_weight: 0.1
-        gaia_dr2_source:
-            join_weight: 0.2
-            skip: True
-        gaia_unwise_agn:
-            join_weight: 0.3
-        legacy_survey_dr8:
-            skip_phases: [2]
-        allwise:
-            skip_phases: [3]
-            query_radius: 6
-        unwise:
-            skip_phases: [3]
-            query_radius: 6
-        catwise:
-            skip_phases: [3]
-            query_radius: 6
-        glimpse:
-            skip_phases: [3]
-            query_radius: 6
-        guvcat:
-            query_radius: 4.5
-        kepler_input_10:
-            ra_column: kic_ra_deg
-            dec_column: kic_dec
-
-'0.1.0-alpha.4':
-    base_version: 0.1.0-alpha.3
-    order:
-        - tic_v8
-        - legacy_survey_dr8
-        - sdss_dr13_photoobj
-        - skymapper_dr1_1
-        - kepler_input_10
-        - bhm_rm_v0
-        - ps1_g18
-        - tycho2
-        - gaia_qso
-        - bhm_csc
-        - gaia_dr2_wd_sdss
-        - guvcat
-        - allwise
-        - unwise
-        - catwise
-        - glimpse
-    tables:
-        tycho2:
-            has_missing_coordinates: true
-        bhm_rm_v0:
-            ra_column: ra
-            dec_column: dec
-        allwise:
-            skip_phases: [3]
-            query_radius: 3
-        unwise:
-            skip_phases: [3]
-            query_radius: 3
-        catwise:
-            skip_phases: [3]
-            query_radius: 3
-        glimpse:
-            skip_phases: [3]
-            query_radius: 3
-        guvcat:
-            query_radius: 2.5
-
-'0.1.0-alpha.5':
-    base_version: 0.1.0-beta.1
-    sample_region:
-        - [270., 66.56, 5.]    # North CVZ
-        - [90., -66.56, 5.]    # South CVZ
-        - [45.0, 0.0, 5.]      # Stripe-82-West
-        - [135.0, 1.0, 5.]     # eFEDS
-        - [315.0, 0.0, 5.]     # Stripe-82-East
-
-# Copy all configuration here instead of using base_version for clarity.
-'0.1.0-beta.1':
-    order:
-        - tic_v8
-        - legacy_survey_dr8
-        - sdss_dr13_photoobj
-        - skymapper_dr1_1
-        - kepler_input_10
-        - bhm_rm_v0
-        - ps1_g18
-        - tycho2
-        - gaia_qso
-        - bhm_csc
-        - gaia_dr2_wd_sdss
-        - guvcat
-        - allwise
-        - unwise
-        - catwise
-        - glimpse
-    key: null
-    exclude: null
-    query_radius: 1.
-    schema: catalogdb
-    output_table: catalog
-    start_node: tic_v8
-    disable_seqscan: false
-    debug: true
-    log_path: xmatch_{version}.log
-    tables:
-        tic_v8:
-            ra_column: ra
-            dec_column: dec
-            pmra_column: pmra
-            pmdec_column: pmdec
-            is_pmra_cos: true
-            parallax_column: plx
-            epoch: 2015.5
-            join_weight: 0.1
-        gaia_dr2_source:
-            ra_column: ra
-            dec_column: dec
-            pmra_column: pmra
-            pmdec_column: pmdec
-            is_pmra_cos: true
-            parallax_column: parallax
-            epoch: 2015.5
-            join_weight: 0.2
-            skip: True
-        legacy_survey_dr8:
-            ra_column: ra
-            dec_column: dec
-            pmra_column: pmra
-            pmdec_column: pmdec
-            is_pmra_cos: true
-            parallax_column: parallax
-            epoch_column: ref_epoch
-            skip_phases: [2]
-        twomass_psc:
-            ra_column: ra
-            dec_column: decl
-            epoch_column: jdate
-            epoch_format: jd
-            skip: true
-        tycho2:
-            ra_column: ramdeg
-            dec_column: demdeg
-            pmra_column: pmra
-            pmdec_column: pmde
-            is_pmra_cos: true
-            epoch: 2000.0
-            has_missing_coordinates: true
-        ps1_g18:
-            ra_column: ramean
-            dec_column: decmean
-        catwise:
-            ra_column: ra_pm
-            dec_column: dec_pm
-            pmra_column: pmra
-            pmdec_column: pmdec
-            has_missing_coordinates: true
-            epoch: 2014.115  # MJD 56700
-            parallax_column: par_pm
-            skip_phases: [3]
-            query_radius: 3
-        guvcat:
-            ra_column: ra
-            dec_column: dec
-            query_radius: 2.5
-        sdss_dr13_photoobj:
-            ra_column: ra
-            dec_column: dec
-        kepler_input_10:
-            ra_column: kic_ra
-            dec_column: kic_dec
-        glimpse:
-            ra_column: ra
-            dec_column: dec
-            skip_phases: [3]
-            query_radius: 3
-        skymapper_dr1_1:
-            ra_column: raj2000
-            dec_column: dej2000
-        gaia_qso:
-            ra_column: raj2000
-            dec_column: dej2000
-        bhm_csc:
-            ra_column: oir_ra
-            dec_column: oir_dec
-        gaia_dr2_wd_sdss:
-            ra_column: ra
-            dec_column: dec
-        unwise:
-            ra_column: ra
-            dec_column: dec
-            skip_phases: [3]
-            query_radius: 3
-        allwise:
-            ra_column: ra
-            dec_column: dec
-            pmra_column: pmra
-            pmdec_column: pmdec
-            epoch: 2010.5589  # MJD 55400.0
-            skip_phases: [3]
-            query_radius: 3
-        bhm_rm_v0:
-            ra_column: ra
-            dec_column: dec
-        gaia_unwise_agn:  # Only for joining.
-            join_weight: 0.3
-
-'0.1.0-beta.2':
-    base_plan: '0.1.0-beta.1'
-    log_path: xmatch_{plan}.log
-    show_sql: true
-    order:
-        - tic_v8
-        - legacy_survey_dr8
-        - sdss_dr13_photoobj_primary
-        - sdss_dr16_specobj
-        - skymapper_dr1_1
-        - kepler_input_10
-        - bhm_rm_v0
-        - ps1_g18
-        - tycho2
-        - gaia_qso
-        - bhm_csc
-        - gaia_dr2_wd_sdss
-        - guvcat
-        - allwise
-        - unwise
-        - catwise
-        - glimpse
-        - uvotssc1
-        - xmm_om_suss_4_1
-    exclude:
-        - skymapper_gaia
-    tables:
-        tic_v8:
-            ra_column: ra
-            dec_column: dec
-            pmra_column: pmra
-            pmdec_column: pmdec
-            is_pmra_cos: true
-            parallax_column: plx
-            epoch: 2000.0
-            join_weight: 0.1
-        sdss_dr16_specobj:
-            ra_column: ra
-            dec_column: dec
-        sdss_dr13_photoobj_primary:
-            ra_column: ra
-            dec_column: dec
-        uvotssc1:
-            ra_column: radeg
-            dec_column: dedeg
-            skip_phases: [3]
-            query_radius: 3
-        xmm_om_suss_4_1:
-            ra_column: ra
-            dec_column: dec
-            skip_phases: [3]
-            query_radius: 3
-    database_options:
-        work_mem: '10GB'
-        temp_buffers: '10GB'
-        maintenance_work_mem: '10GB'
-
-'0.1.0-alpha.5':
-    base_plan: '0.1.0-beta.2'
-    sample_region:
-        - [270., 66.56, 5.]    # North CVZ
-        - [90., -66.56, 5.]    # South CVZ
-        - [45.0, 0.0, 5.]      # Stripe-82-West
-        - [135.0, 1.0, 5.]     # eFEDS
-        - [315.0, 0.0, 5.]     # Stripe-82-East
-
-'0.1.0-alpha.6':
-    base_plan: '0.1.0-alpha.5'
-
-'0.1.0-alpha.7':
-    base_plan: '0.1.0-alpha.5'
-    database_options:
-        work_mem: '10GB'
-        temp_buffers: '10GB'
-        maintenance_work_mem: '60GB'
-
-'0.1.0':
-    base_plan: '0.1.0-beta.2'
+'0.5.0-beta.1':
+  version_bit: 1
+  order:
+    - tic_v8
+    - legacy_survey_dr8
+    - panstarrs1
+    - supercosmos
+    - sdss_dr13_photoobj_primary
+    - sdss_dr16_specobj
+    - skymapper_dr2
+    - kepler_input_10
+    - bhm_rm_v0
+    - ps1_g18
+    - tycho2
+    - gaia_qso
+    - bhm_csc
+    - gaia_dr2_wd_sdss
+    - guvcat
+    - allwise
+    - unwise
+    - catwise2020
+    - glimpse
+    - glimpse360
+    - uvotssc1
+    - xmm_om_suss_4_1
+  exclude:
+    - skymapper_gaia
+  sample_region:
+    - [270., 66.56, 5.] # North CVZ
+    - [90., -66.56, 5.] # South CVZ
+    - [45.0, 0.0, 5.] # Stripe-82-West
+    - [135.0, 1.0, 5.] # eFEDS
+    - [315.0, 0.0, 5.] # Stripe-82-East
+  key: null
+  query_radius: 1.
+  schema: catalogdb
+  output_table: catalog
+  start_node: tic_v8
+  disable_seqscan: false
+  debug: true
+  log_path: xmatch_{version}.log
+  tables:
+    tic_v8:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: plx
+      epoch: 2000.0
+      join_weight: 0.1
+    gaia_dr2_source:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: parallax
+      epoch: 2015.5
+      join_weight: 0.2
+      skip: True
+    legacy_survey_dr8:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: parallax
+      epoch_column: ref_epoch
+      skip_phases: [2]
+    twomass_psc:
+      ra_column: ra
+      dec_column: decl
+      epoch_column: jdate
+      epoch_format: jd
+      skip: true
+    tycho2:
+      ra_column: ramdeg
+      dec_column: demdeg
+      pmra_column: pmra
+      pmdec_column: pmde
+      is_pmra_cos: true
+      epoch: 2000.0
+      has_missing_coordinates: true
+    ps1_g18:
+      ra_column: ramean
+      dec_column: decmean
+    catwise2020:
+      ra_column: ra_pm
+      dec_column: dec_pm
+      pmra_column: pmra
+      pmdec_column: pmdec
+      has_missing_coordinates: true
+      epoch: 2015.402 # MJD 57170
+      parallax_column: par_pm
+      skip_phases: [3]
+      query_radius: 3
+    guvcat:
+      ra_column: ra
+      dec_column: dec
+      query_radius: 2.5
+    sdss_dr13_photoobj_primary:
+      ra_column: ra
+      dec_column: dec
+    sdss_dr16_specobj:
+      ra_column: ra
+      dec_column: dec
+    uvotssc1:
+      ra_column: radeg
+      dec_column: dedeg
+      skip_phases: [3]
+      query_radius: 3
+    xmm_om_suss_4_1:
+      ra_column: ra
+      dec_column: dec
+      skip_phases: [3]
+      query_radius: 3
+    kepler_input_10:
+      ra_column: kic_ra
+      dec_column: kic_dec
+    glimpse:
+      ra_column: ra
+      dec_column: dec
+      skip_phases: [3]
+      query_radius: 3
+    glimpse360:
+      ra_column: ra
+      dec_column: dec
+      skip_phases: [3]
+      query_radius: 3
+    skymapper_dr2:
+      ra_column: raj2000
+      dec_column: dej2000
+    gaia_qso:
+      ra_column: raj2000
+      dec_column: dej2000
+    bhm_csc:
+      ra_column: oir_ra
+      dec_column: oir_dec
+    gaia_dr2_wd_sdss:
+      ra_column: ra
+      dec_column: dec
+    unwise:
+      ra_column: ra
+      dec_column: dec
+      skip_phases: [3]
+      query_radius: 3
+    allwise:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      epoch: 2010.5589 # MJD 55400.0
+      skip_phases: [3]
+      query_radius: 3
+    bhm_rm_v0:
+      ra_column: ra
+      dec_column: dec
+    gaia_unwise_agn: # Only for joining.
+      join_weight: 0.3
+    panstarrs1:
+      ra_column: ra
+      dec_column: dec
+      query_radius: 1
+    supercosmos:
+      ra_column: ra
+      dec_column: dec
+      query_radius: 1
+  database_options:
+    work_mem: '10GB'
+    temp_buffers: '10GB'
+    maintenance_work_mem: '10GB'

--- a/python/target_selection/config/xmatch.yml
+++ b/python/target_selection/config/xmatch.yml
@@ -145,6 +145,7 @@
     bhm_csc:
       ra_column: oir_ra
       dec_column: oir_dec
+      query_radius: 2
     gaia_dr2_wd_sdss:
       ra_column: ra
       dec_column: dec

--- a/python/target_selection/config/xmatch.yml
+++ b/python/target_selection/config/xmatch.yml
@@ -37,9 +37,8 @@
   schema: catalogdb
   output_table: catalog
   start_node: tic_v8
-  disable_seqscan: false
   debug: true
-  log_path: xmatch_{version}.log
+  log_path: xmatch_{plan}.log
   tables:
     tic_v8:
       ra_column: ra

--- a/python/target_selection/config/xmatch.yml
+++ b/python/target_selection/config/xmatch.yml
@@ -98,7 +98,7 @@
     guvcat:
       ra_column: ra
       dec_column: dec
-      query_radius: 2.5
+      query_radius: 1.5
     sdss_dr13_photoobj_primary:
       ra_column: ra
       dec_column: dec

--- a/python/target_selection/config/xmatch.yml
+++ b/python/target_selection/config/xmatch.yml
@@ -2,6 +2,7 @@
   run_id: 1
   order:
     - tic_v8
+    - tic_v8_extended
     - legacy_survey_dr8
     - panstarrs1
     - supercosmos
@@ -49,6 +50,14 @@
       parallax_column: plx
       epoch: 2000.0
       join_weight: 0.1
+    tic_v8_extended:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: plx
+      epoch: 2000.0
     gaia_dr2_source:
       ra_column: ra
       dec_column: dec

--- a/python/target_selection/config/xmatch.yml
+++ b/python/target_selection/config/xmatch.yml
@@ -28,10 +28,10 @@
     - skymapper_gaia
   sample_region:
     - [270., 66.56, 5.] # North CVZ
-    # - [90., -66.56, 5.] # South CVZ
-    # - [45.0, 0.0, 5.] # Stripe-82-West
-    # - [135.0, 1.0, 5.] # eFEDS
-    # - [315.0, 0.0, 5.] # Stripe-82-East
+    - [90., -66.56, 5.] # South CVZ
+    - [45.0, 0.0, 5.] # Stripe-82-West
+    - [135.0, 1.0, 5.] # eFEDS
+    - [315.0, 0.0, 5.] # Stripe-82-East
   key: null
   query_radius: 1.
   schema: catalogdb

--- a/python/target_selection/config/xmatch.yml
+++ b/python/target_selection/config/xmatch.yml
@@ -28,10 +28,10 @@
     - skymapper_gaia
   sample_region:
     - [270., 66.56, 5.] # North CVZ
-    - [90., -66.56, 5.] # South CVZ
-    - [45.0, 0.0, 5.] # Stripe-82-West
-    - [135.0, 1.0, 5.] # eFEDS
-    - [315.0, 0.0, 5.] # Stripe-82-East
+    # - [90., -66.56, 5.] # South CVZ
+    # - [45.0, 0.0, 5.] # Stripe-82-West
+    # - [135.0, 1.0, 5.] # eFEDS
+    # - [315.0, 0.0, 5.] # Stripe-82-East
   key: null
   query_radius: 1.
   schema: catalogdb

--- a/python/target_selection/config/xmatch.yml
+++ b/python/target_selection/config/xmatch.yml
@@ -1,5 +1,5 @@
 '0.5.0-beta.1':
-  version_bit: 1
+  run_id: 1
   order:
     - tic_v8
     - legacy_survey_dr8

--- a/python/target_selection/config/xmatch_v0.yml
+++ b/python/target_selection/config/xmatch_v0.yml
@@ -1,0 +1,418 @@
+'0.1.0-alpha.1':
+  order: hierarchical
+  key: resolution
+  query_radius: 1.
+  schema: catalogdb
+  output_table: catalog
+  start_node: tic_v8
+  debug: true
+  log_path: false
+  disable_seqscan: true
+  sample_region:
+    - [270., 66.56, 5.] # North CVZ
+    - [90., -66.56, 5.] # South CVZ
+    - [45.0, 0.0, 5.] # Stripe-82-West
+    - [135.0, 1.0, 5.] # eFEDS
+    - [315.0, 0.0, 5.] # Stripe-82-East
+  exclude: null
+  tables:
+    tic_v8:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: plx
+      epoch: 2015.5
+      skip: false
+    gaia_dr2_source:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: parallax
+      epoch: 2015.5
+      skip: true
+    legacy_survey_dr8:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: parallax
+      epoch_column: ref_epoch
+    twomass_psc:
+      ra_column: ra
+      dec_column: decl
+      epoch_column: jdate
+      epoch_format: jd
+      skip: true
+    tycho2:
+      ra_column: ramdeg
+      dec_column: demdeg
+      pmra_column: pmra
+      pmdec_column: pmde
+      is_pmra_cos: true
+      epoch: 2000.0
+    ps1_g18:
+      ra_column: ramean
+      dec_column: decmean
+    catwise:
+      ra_column: ra_pm
+      dec_column: dec_pm
+      pmra_column: pmra
+      pmdec_column: pmdec
+      epoch: 2014.115 # MJD 56700
+      parallax_column: par_pm
+    guvcat:
+      ra_column: ra
+      dec_column: dec
+    sdss_dr13_photoobj:
+      ra_column: ra
+      dec_column: dec
+    kepler_input_10:
+      ra_column: kic_ra
+      dec_column: kic_dec
+    glimpse:
+      ra_column: ra
+      dec_column: dec
+    skymapper_dr1_1:
+      ra_column: raj2000
+      dec_column: dej2000
+    gaia_qso:
+      ra_column: raj2000
+      dec_column: dej2000
+    bhm_csc:
+      ra_column: oir_ra
+      dec_column: oir_dec
+    gaia_dr2_wd_sdss:
+      ra_column: ra
+      dec_column: dec
+    unwise:
+      ra_column: ra
+      dec_column: dec
+
+'0.1.0-alpha.2':
+  base_version: 0.1.0-alpha.1
+  key: row_count
+  log_path: xmatch_{version}.log
+  exclude: ['kepler_input_10']
+  tables:
+    allwise:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      epoch: 2010.5589 # MJD 55400.0
+    gaia_dr2_source:
+      join_weight: 0.1
+      skip: True
+    gaia_unwise_agn:
+      join_weight: 0.3
+
+'0.1.0-alpha.3':
+  base_version: 0.1.0-alpha.2
+  order:
+    - tic_v8
+    - legacy_survey_dr8
+    - sdss_dr13_photoobj
+    - skymapper_dr1_1
+    - kepler_input_10
+    - ps1_g18
+    - tycho2
+    - gaia_qso
+    - bhm_csc
+    - gaia_dr2_wd_sdss
+    - guvcat
+    - allwise
+    - unwise
+    - catwise
+    - glimpse
+  key: null
+  exclude: null
+  tables:
+    tic_v8:
+      join_weight: 0.1
+    gaia_dr2_source:
+      join_weight: 0.2
+      skip: True
+    gaia_unwise_agn:
+      join_weight: 0.3
+    legacy_survey_dr8:
+      skip_phases: [2]
+    allwise:
+      skip_phases: [3]
+      query_radius: 6
+    unwise:
+      skip_phases: [3]
+      query_radius: 6
+    catwise:
+      skip_phases: [3]
+      query_radius: 6
+    glimpse:
+      skip_phases: [3]
+      query_radius: 6
+    guvcat:
+      query_radius: 4.5
+    kepler_input_10:
+      ra_column: kic_ra_deg
+      dec_column: kic_dec
+
+'0.1.0-alpha.4':
+  base_version: 0.1.0-alpha.3
+  order:
+    - tic_v8
+    - legacy_survey_dr8
+    - sdss_dr13_photoobj
+    - skymapper_dr1_1
+    - kepler_input_10
+    - bhm_rm_v0
+    - ps1_g18
+    - tycho2
+    - gaia_qso
+    - bhm_csc
+    - gaia_dr2_wd_sdss
+    - guvcat
+    - allwise
+    - unwise
+    - catwise
+    - glimpse
+  tables:
+    tycho2:
+      has_missing_coordinates: true
+    bhm_rm_v0:
+      ra_column: ra
+      dec_column: dec
+    allwise:
+      skip_phases: [3]
+      query_radius: 3
+    unwise:
+      skip_phases: [3]
+      query_radius: 3
+    catwise:
+      skip_phases: [3]
+      query_radius: 3
+    glimpse:
+      skip_phases: [3]
+      query_radius: 3
+    guvcat:
+      query_radius: 2.5
+
+'0.1.0-alpha.5':
+  base_version: 0.1.0-beta.1
+  sample_region:
+    - [270., 66.56, 5.] # North CVZ
+    - [90., -66.56, 5.] # South CVZ
+    - [45.0, 0.0, 5.] # Stripe-82-West
+    - [135.0, 1.0, 5.] # eFEDS
+    - [315.0, 0.0, 5.] # Stripe-82-East
+
+# Copy all configuration here instead of using base_version for clarity.
+'0.1.0-beta.1':
+  order:
+    - tic_v8
+    - legacy_survey_dr8
+    - sdss_dr13_photoobj
+    - skymapper_dr1_1
+    - kepler_input_10
+    - bhm_rm_v0
+    - ps1_g18
+    - tycho2
+    - gaia_qso
+    - bhm_csc
+    - gaia_dr2_wd_sdss
+    - guvcat
+    - allwise
+    - unwise
+    - catwise
+    - glimpse
+  key: null
+  exclude: null
+  query_radius: 1.
+  schema: catalogdb
+  output_table: catalog
+  start_node: tic_v8
+  disable_seqscan: false
+  debug: true
+  log_path: xmatch_{version}.log
+  tables:
+    tic_v8:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: plx
+      epoch: 2015.5
+      join_weight: 0.1
+    gaia_dr2_source:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: parallax
+      epoch: 2015.5
+      join_weight: 0.2
+      skip: True
+    legacy_survey_dr8:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: parallax
+      epoch_column: ref_epoch
+      skip_phases: [2]
+    twomass_psc:
+      ra_column: ra
+      dec_column: decl
+      epoch_column: jdate
+      epoch_format: jd
+      skip: true
+    tycho2:
+      ra_column: ramdeg
+      dec_column: demdeg
+      pmra_column: pmra
+      pmdec_column: pmde
+      is_pmra_cos: true
+      epoch: 2000.0
+      has_missing_coordinates: true
+    ps1_g18:
+      ra_column: ramean
+      dec_column: decmean
+    catwise:
+      ra_column: ra_pm
+      dec_column: dec_pm
+      pmra_column: pmra
+      pmdec_column: pmdec
+      has_missing_coordinates: true
+      epoch: 2014.115 # MJD 56700
+      parallax_column: par_pm
+      skip_phases: [3]
+      query_radius: 3
+    guvcat:
+      ra_column: ra
+      dec_column: dec
+      query_radius: 2.5
+    sdss_dr13_photoobj:
+      ra_column: ra
+      dec_column: dec
+    kepler_input_10:
+      ra_column: kic_ra
+      dec_column: kic_dec
+    glimpse:
+      ra_column: ra
+      dec_column: dec
+      skip_phases: [3]
+      query_radius: 3
+    skymapper_dr1_1:
+      ra_column: raj2000
+      dec_column: dej2000
+    gaia_qso:
+      ra_column: raj2000
+      dec_column: dej2000
+    bhm_csc:
+      ra_column: oir_ra
+      dec_column: oir_dec
+    gaia_dr2_wd_sdss:
+      ra_column: ra
+      dec_column: dec
+    unwise:
+      ra_column: ra
+      dec_column: dec
+      skip_phases: [3]
+      query_radius: 3
+    allwise:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      epoch: 2010.5589 # MJD 55400.0
+      skip_phases: [3]
+      query_radius: 3
+    bhm_rm_v0:
+      ra_column: ra
+      dec_column: dec
+    gaia_unwise_agn: # Only for joining.
+      join_weight: 0.3
+
+'0.1.0-beta.2':
+  base_plan: '0.1.0-beta.1'
+  log_path: xmatch_{plan}.log
+  show_sql: true
+  order:
+    - tic_v8
+    - legacy_survey_dr8
+    - sdss_dr13_photoobj_primary
+    - sdss_dr16_specobj
+    - skymapper_dr1_1
+    - kepler_input_10
+    - bhm_rm_v0
+    - ps1_g18
+    - tycho2
+    - gaia_qso
+    - bhm_csc
+    - gaia_dr2_wd_sdss
+    - guvcat
+    - allwise
+    - unwise
+    - catwise
+    - glimpse
+    - uvotssc1
+    - xmm_om_suss_4_1
+  exclude:
+    - skymapper_gaia
+  tables:
+    tic_v8:
+      ra_column: ra
+      dec_column: dec
+      pmra_column: pmra
+      pmdec_column: pmdec
+      is_pmra_cos: true
+      parallax_column: plx
+      epoch: 2000.0
+      join_weight: 0.1
+    sdss_dr16_specobj:
+      ra_column: ra
+      dec_column: dec
+    sdss_dr13_photoobj_primary:
+      ra_column: ra
+      dec_column: dec
+    uvotssc1:
+      ra_column: radeg
+      dec_column: dedeg
+      skip_phases: [3]
+      query_radius: 3
+    xmm_om_suss_4_1:
+      ra_column: ra
+      dec_column: dec
+      skip_phases: [3]
+      query_radius: 3
+  database_options:
+    work_mem: '10GB'
+    temp_buffers: '10GB'
+    maintenance_work_mem: '10GB'
+
+'0.1.0-alpha.6':
+  base_plan: '0.1.0-beta.2'
+  sample_region:
+    - [270., 66.56, 5.] # North CVZ
+    - [90., -66.56, 5.] # South CVZ
+    - [45.0, 0.0, 5.] # Stripe-82-West
+    - [135.0, 1.0, 5.] # eFEDS
+    - [315.0, 0.0, 5.] # Stripe-82-East
+
+'0.1.0-alpha.7':
+  base_plan: '0.1.0-alpha.6'
+
+'0.1.0-alpha.8':
+  base_plan: '0.1.0-alpha.6'
+  database_options:
+    work_mem: '10GB'
+    temp_buffers: '10GB'
+    maintenance_work_mem: '60GB'
+
+'0.1.0':
+  base_plan: '0.1.0-beta.2'

--- a/python/target_selection/xmatch.py
+++ b/python/target_selection/xmatch.py
@@ -1423,7 +1423,8 @@ class XMatchPlanner(object):
                             model_pk.alias('target_id'),
                             q3c_dist.alias('distance'))
                     .join(model, peewee.JOIN.CROSS)
-                    .where(q3c_join))
+                    .where(q3c_join)
+                    .where(self._get_sample_where(model_ra, model_dec)))
 
         # This may break the use of the index but I think it's needed if
         # the model is the second table in q3c_join and has empty RA/Dec.

--- a/python/target_selection/xmatch.py
+++ b/python/target_selection/xmatch.py
@@ -1660,6 +1660,10 @@ class XMatchPlanner(object):
         self._phases_run.add(3)
         self._analyze(rel_model, catalog=True)
 
+        self.log.debug(f'Running CLUSTER on {self._temp_table} with q3c index.')
+        self.database.execute_sql(f'CLUSTER {self._temp_table} '
+                                  f'using {self._temp_table}_q3c_idx;')
+
     def _load_output_table(self, keep_temp=False):
         """Copies the temporary table to the real output table."""
 

--- a/python/target_selection/xmatch.py
+++ b/python/target_selection/xmatch.py
@@ -1341,8 +1341,6 @@ class XMatchPlanner(object):
             self.log.debug(f'Linked {nids:,} records in {timer.interval:.3f} s.')
             self._analyze(rel_model)
 
-        self._phases_run.add(1)
-
     def _run_phase_2(self, model):
         """Associates existing targets in Catalog with entries in the model."""
 

--- a/python/target_selection/xmatch.py
+++ b/python/target_selection/xmatch.py
@@ -1339,7 +1339,8 @@ class XMatchPlanner(object):
                         self._phases_run.add(1)
 
             self.log.debug(f'Linked {nids:,} records in {timer.interval:.3f} s.')
-            self._analyze(rel_model)
+
+        self._analyze(rel_model)
 
     def _run_phase_2(self, model):
         """Associates existing targets in Catalog with entries in the model."""

--- a/python/target_selection/xmatch.py
+++ b/python/target_selection/xmatch.py
@@ -1478,7 +1478,7 @@ class XMatchPlanner(object):
                 # make sure the Q3C index is used.
                 self._setup_transaction(model, phase=2)
 
-                # 2. Run cross-match and insert data into relationa; model.
+                # 2. Run cross-match and insert data into relational model.
 
                 fields = [rel_model.target_id, rel_model.catalogid,
                           rel_model.version_id, rel_model.distance,
@@ -1497,8 +1497,9 @@ class XMatchPlanner(object):
                        f'{n_catalogid:,} targets in {table_name}. '
                        f'Run in {timer.interval:.3f} s.')
 
-        self._phases_run.add(2)
-        self._analyze(rel_model)
+        if n_catalogid > 0:
+            self._phases_run.add(2)
+            self._analyze(rel_model)
 
     def _run_phase_3(self, model):
         """Add non-matched targets to Catalog and the relational table."""

--- a/python/target_selection/xmatch.py
+++ b/python/target_selection/xmatch.py
@@ -1340,7 +1340,8 @@ class XMatchPlanner(object):
 
             self.log.debug(f'Linked {nids:,} records in {timer.interval:.3f} s.')
 
-        self._analyze(rel_model)
+        if 1 in self._phases_run:
+            self._analyze(rel_model)
 
     def _run_phase_2(self, model):
         """Associates existing targets in Catalog with entries in the model."""
@@ -1507,12 +1508,13 @@ class XMatchPlanner(object):
 
         self.log.info('Phase 3: adding non cross-matched targets.')
 
-        if 3 in xmatch.skip_phases:
-            self.log.warning('Skipping due to configuration.')
-            return
-
         rel_model = self._get_relational_model(model, create=True)
         rel_table_name = rel_model._meta.table_name
+
+        if 3 in xmatch.skip_phases:
+            self.log.warning('Skipping due to configuration.')
+            self._analyze(rel_model, catalog=True)
+            return
 
         table_name = meta.table_name
 

--- a/python/target_selection/xmatch.py
+++ b/python/target_selection/xmatch.py
@@ -1029,7 +1029,7 @@ class XMatchPlanner(object):
                 model = self.models[table_name]
                 self.process_model(model)
 
-        self._load_output_table(keep_temp=keep_temp)
+            self._load_output_table(keep_temp=keep_temp)
 
         self.log.info(f'Cross-matching completed in {timer.interval:.3f} s.')
 

--- a/python/target_selection/xmatch.py
+++ b/python/target_selection/xmatch.py
@@ -1553,6 +1553,10 @@ class XMatchPlanner(object):
             unmatched = unmatched.where(model_ra.is_null(False),
                                         model_dec.is_null(False))
 
+        # TODO: this is horrible and should be moved to the configuration in some form.
+        if model._meta.table_name == 'tic_v8':
+            unmatched = unmatched.where(model.objtype != 'EXTENDED')
+
         with Timer() as timer:
             with self.database.atomic():
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-target-selection
-version = 0.1.5-alpha.0
+version = 0.2.0-beta.0
 author = José Sánchez-Gallego
 author_email = gallegoj@uw.edu
 description = Code to perform target selection for BHM/MWM using catalogdb


### PR DESCRIPTION
- Added configuration for v0.5.
- Implement `run_id` and `catalogid` with `run_id` bit shifting.
- Use `ra_orig` and `dec_orig` from TIC_v8 when `posflag=gaia2`.
- Reject extended sources when matching against TIC_v8.
- Cluster temporary table after phase 3.
- Always cross-match model against temporary table in phase 2.
- More consistent use of `ANALYZE` after phases.
