### PR TITLE
Sky boss v05

### DIFF
--- a/python/target_selection/cartons/ops_skies.py
+++ b/python/target_selection/cartons/ops_skies.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu), Updated Nov 2021 by Tom Dwelly
 # @Date: 2020-07-26
 # @Filename: ops_skies.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
@@ -9,103 +9,9 @@
 import peewee
 from peewee import fn
 
-# from . import BaseCarton
 from target_selection.cartons.base import BaseCarton
 
-from sdssdb.peewee.sdss5db.catalogdb import CatalogToSkies_v1, Skies_v1
 from sdssdb.peewee.sdss5db.catalogdb import CatalogToSkies_v2, Skies_v2
-
-
-# class OPS_BOSS_Sky_Carton(BaseCarton):
-#     """Skies for the BOSS spectrograph.
-#
-#     Definition:
-#         Select sky positions from catalogdb.skies_v1 that don't have a
-#         nearby Gaia, LS8, Tycho2, or 2MASS source.
-#
-#     """
-#
-#     name = 'ops_sky_boss'
-#     cadence = None
-#     category = 'ops_sky'
-#     program = 'SKY'
-#     mapper = None
-#     priority = 5000
-#
-#     load_magnitudes = False
-#
-#     def build_query(self, version_id, query_region):
-#
-#         min_separation = 10 + ((12. - Skies_v1.mag_neighbour_gaia) / 0.2)
-#
-#         query = (Skies_v1
-#                  .select(CatalogToSkies_v1.catalogid,
-#                          Skies_v1.ra,
-#                          Skies_v1.dec,
-#                          Skies_v1.pix_32768,
-#                          Skies_v1.tile_32)
-#                  .join(CatalogToSkies_v1)
-#                  .where(Skies_v1.sep_neighbour_gaia > min_separation)
-#                  .where(CatalogToSkies_v1.version_id == version_id,
-#                         CatalogToSkies_v1.best >> True)
-#                  .where(Skies_v1.gaia_sky >> True,
-#                         Skies_v1.ls8_sky >> True,
-#                         Skies_v1.tmass_sky >> True,
-#                         Skies_v1.tycho2_sky >> True,
-#                         Skies_v1.tmass_xsc_sky >> True))
-#
-#         if query_region:
-#             query = (query
-#                      .where(peewee.fn.q3c_radial_query(Skies_v1.ra,
-#                                                        Skies_v1.dec,
-#                                                        query_region[0],
-#                                                        query_region[1],
-#                                                        query_region[2])))
-#
-#         return query
-
-
-class OPS_APOGEE_Sky_Carton(BaseCarton):
-    """Skies for the APOGEE spectrograph.
-
-    Definition:
-        Select sky positions from catalogdb.skies_v1 that don't have a
-        nearby Gaia, Tycho2, or 2MASS source.
-
-    """
-
-    name = 'ops_sky_apogee'
-    cadence = None
-    category = 'ops_sky'
-    program = 'SKY'
-    mapper = None
-    priority = 5200
-
-    load_magnitudes = False
-
-    def build_query(self, version_id, query_region):
-
-        query = (Skies_v1
-                 .select(CatalogToSkies_v1.catalogid,
-                         Skies_v1.ra, Skies_v1.dec,
-                         Skies_v1.pix_32768, Skies_v1.tile_32)
-                 .join(CatalogToSkies_v1)
-                 .where(CatalogToSkies_v1.version_id == version_id,
-                        CatalogToSkies_v1.best >> True)
-                 .where(Skies_v1.gaia_sky >> True,
-                        Skies_v1.tmass_sky >> True,
-                        Skies_v1.tycho2_sky >> True,
-                        Skies_v1.tmass_xsc_sky >> True))
-
-        if query_region:
-            query = (query
-                     .where(peewee.fn.q3c_radial_query(Skies_v1.ra,
-                                                       Skies_v1.dec,
-                                                       query_region[0],
-                                                       query_region[1],
-                                                       query_region[2])))
-
-        return query
 
 
 class OPS_Sky_Boss_Best_Carton(BaseCarton):
@@ -115,7 +21,9 @@ class OPS_Sky_Boss_Best_Carton(BaseCarton):
         Select sky positions from catalogdb.skies_v2 that don't have a
         nearby Gaia, Tycho2, or 2MASS source and that are
         valid in either lsdr8 or ps1dr2.
-        Take care near edges of ls8 and ps1dr2 footprints
+        Take care near edges of ls8 and ps1dr2 footprints by selecting
+        only sky locations that have at least one neighbour (not too close)
+        in their originating catalogue.
 
     """
 
@@ -132,7 +40,6 @@ class OPS_Sky_Boss_Best_Carton(BaseCarton):
 
     def build_query(self, version_id, query_region=None):
         pars = self.parameters
-        # min_separation = 10 + ((12. - Skies_v2.mag_neighbour_gaia) / 0.2)
 
         query = (
             Skies_v2
@@ -140,22 +47,8 @@ class OPS_Sky_Boss_Best_Carton(BaseCarton):
                 CatalogToSkies_v2.catalogid,
                 Skies_v2.ra,
                 Skies_v2.dec,
-                # Skies_v2.pix_32768,  # extra
-                # Skies_v2.tile_32,  # extra
-                # Skies_v2.sep_neighbour_gaia,  # extra
-                # Skies_v2.mag_neighbour_gaia,  # extra
-                # Skies_v2.valid_ls8,  # extra
-                # Skies_v2.sep_neighbour_ls8,  # extra
-                # Skies_v2.mag_neighbour_ls8,  # extra
-                # Skies_v2.valid_ps1dr2,  # extra
-                # Skies_v2.sep_neighbour_ps1dr2,  # extra
-                # Skies_v2.mag_neighbour_ps1dr2,  # extra
-                # min_separation.alias("min_separation_gaia_lim")  # extra
             )
             .join(CatalogToSkies_v2)
-            # .where(Skies_v2.sep_neighbour_gaia > min_separation)
-            # .where(Skies_v2.tile_32 >= 6000,
-            #        Skies_v2.tile_32 <= 7000)
             .where(CatalogToSkies_v2.version_id == version_id,
                    CatalogToSkies_v2.best >> True)
             .where(Skies_v2.valid_gaia >> True,
@@ -188,7 +81,7 @@ class OPS_Sky_Boss_Best_Carton(BaseCarton):
 
 
 class OPS_Sky_Boss_Fallback_Carton(BaseCarton):
-    """Fallback quality skies for the BOSS spectrograph.
+    """Reasonable quality skies for the BOSS spectrograph.
 
     Definition:
         Select sky positions from catalogdb.skies_v2 that don't have a
@@ -208,7 +101,7 @@ class OPS_Sky_Boss_Fallback_Carton(BaseCarton):
     load_magnitudes = False
 
     def build_query(self, version_id, query_region=None):
-        min_separation = 10 + ((12. - Skies_v2.mag_neighbour_gaia) / 0.2)
+        pars = self.parameters
 
         query = (
             Skies_v2
@@ -216,22 +109,9 @@ class OPS_Sky_Boss_Fallback_Carton(BaseCarton):
                 CatalogToSkies_v2.catalogid,
                 Skies_v2.ra,
                 Skies_v2.dec,
-                # Skies_v2.pix_32768,  # extra
-                # Skies_v2.tile_32,  # extra
-                Skies_v2.sep_neighbour_gaia,  # extra
-                Skies_v2.mag_neighbour_gaia,  # extra
-                Skies_v2.valid_ls8,  # extra
-                Skies_v2.sep_neighbour_ls8,  # extra
-                Skies_v2.mag_neighbour_ls8,  # extra
-                Skies_v2.valid_ps1dr2,  # extra
-                Skies_v2.sep_neighbour_ps1dr2,  # extra
-                Skies_v2.mag_neighbour_ps1dr2,  # extra
-                min_separation.alias("min_separation_gaia_lim"),  # extra
             )
             .join(CatalogToSkies_v2)
-            .where(Skies_v2.tile_32 >= 6000,
-                   Skies_v2.tile_32 <= 7000)
-            # .where(Skies_v2.sep_neighbour_gaia > min_separation)
+            .where(Skies_v2.sep_neighbour_gaia > pars['min_sep_gaia'])
             .where(CatalogToSkies_v2.version_id == version_id,
                    CatalogToSkies_v2.best >> True)
             .where(Skies_v2.valid_gaia >> True,

--- a/python/target_selection/cartons/ops_skies.py
+++ b/python/target_selection/cartons/ops_skies.py
@@ -9,9 +9,9 @@
 import peewee
 from peewee import fn
 
-from target_selection.cartons.base import BaseCarton
-
 from sdssdb.peewee.sdss5db.catalogdb import CatalogToSkies_v2, Skies_v2
+
+from target_selection.cartons.base import BaseCarton
 
 
 class OPS_Sky_Boss_Best_Carton(BaseCarton):

--- a/python/target_selection/cartons/ops_skies.py
+++ b/python/target_selection/cartons/ops_skies.py
@@ -13,6 +13,15 @@ from sdssdb.peewee.sdss5db.catalogdb import CatalogToSkies_v2, Skies_v2
 
 from target_selection.cartons.base import BaseCarton
 
+# ############################################
+# ############################################
+# ############################################
+# ############################################
+# This module provides the following cartons in v0.5:
+#  *  ops_sky_boss_best
+#  *  ops_sky_boss_good
+#  *  #### ops_sky_boss_fallback   <- not sure how to implement this
+
 
 class OPS_Sky_Boss_Best_Carton(BaseCarton):
     """Top quality skies for the BOSS spectrograph.
@@ -20,7 +29,7 @@ class OPS_Sky_Boss_Best_Carton(BaseCarton):
     Definition:
         Select sky positions from catalogdb.skies_v2 that don't have a
         nearby Gaia, Tycho2, or 2MASS source and that are
-        valid in either lsdr8 or ps1dr2.
+        valid in at least lsdr8 OR ps1dr2 (and not obviously invalid in the other).
         Take care near edges of ls8 and ps1dr2 footprints by selecting
         only sky locations that have at least one neighbour (not too close)
         in their originating catalogue.
@@ -39,6 +48,7 @@ class OPS_Sky_Boss_Best_Carton(BaseCarton):
     load_magnitudes = False
 
     def build_query(self, version_id, query_region=None):
+        a_large_value = 1e30
         pars = self.parameters
 
         query = (
@@ -47,6 +57,8 @@ class OPS_Sky_Boss_Best_Carton(BaseCarton):
                 CatalogToSkies_v2.catalogid,
                 Skies_v2.ra,
                 Skies_v2.dec,
+                Skies_v2.pix_32768,
+                Skies_v2.tile_32,
             )
             .join(CatalogToSkies_v2)
             .where(CatalogToSkies_v2.version_id == version_id,
@@ -56,8 +68,8 @@ class OPS_Sky_Boss_Best_Carton(BaseCarton):
                    Skies_v2.valid_tycho2 >> True,
                    Skies_v2.valid_tmass_xsc >> True)
             .where(
-                fn.COALESCE(Skies_v2.sep_neighbour_ls8, 1e30) > pars['min_sep_ls8'],
-                fn.COALESCE(Skies_v2.sep_neighbour_ps1dr2, 1e30) > pars['min_sep_ps1dr2'],
+                fn.COALESCE(Skies_v2.sep_neighbour_ls8, a_large_value) > pars['min_sep_ls8'],
+                fn.COALESCE(Skies_v2.sep_neighbour_ps1dr2, a_large_value) > pars['min_sep_ps1dr2'],
                 (
                     (Skies_v2.valid_ls8 >> True) &
                     (Skies_v2.sep_neighbour_ls8 < pars['max_sep_ls8'])
@@ -80,16 +92,19 @@ class OPS_Sky_Boss_Best_Carton(BaseCarton):
         return query
 
 
-class OPS_Sky_Boss_Fallback_Carton(BaseCarton):
+class OPS_Sky_Boss_Good_Carton(BaseCarton):
     """Reasonable quality skies for the BOSS spectrograph.
+       Use these skies when there are not enough OPS_Sky_Boss_Best_Carton skies available
 
     Definition:
         Select sky positions from catalogdb.skies_v2 that don't have a
-        nearby Gaia, Tycho2, or 2MASS source
+        nearby Gaia, Tycho2, or 2MASS source.
+        Results in a catalogue that covers the vast majority of the sky,
+        excluding only the Galactic bulge and inner parts of the Magellanic clouds.
 
     """
 
-    name = 'ops_sky_boss_fallback'
+    name = 'ops_sky_boss_good'
     cadence = None
     category = 'ops_sky'
     program = 'SKY'
@@ -109,6 +124,8 @@ class OPS_Sky_Boss_Fallback_Carton(BaseCarton):
                 CatalogToSkies_v2.catalogid,
                 Skies_v2.ra,
                 Skies_v2.dec,
+                Skies_v2.pix_32768,
+                Skies_v2.tile_32,
             )
             .join(CatalogToSkies_v2)
             .where(Skies_v2.sep_neighbour_gaia > pars['min_sep_gaia'])

--- a/python/target_selection/cartons/ops_skies.py
+++ b/python/target_selection/cartons/ops_skies.py
@@ -7,59 +7,62 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 
 import peewee
+from peewee import fn
+
+# from . import BaseCarton
+from target_selection.cartons.base import BaseCarton
 
 from sdssdb.peewee.sdss5db.catalogdb import CatalogToSkies_v1, Skies_v1
+from sdssdb.peewee.sdss5db.catalogdb import CatalogToSkies_v2, Skies_v2
 
-from . import BaseCarton
 
-
-class OPS_BOSS_Sky_Carton(BaseCarton):
-    """Skies for the BOSS spectrograph.
-
-    Definition:
-        Select sky positions from catalogdb.skies_v1 that don't have a
-        nearby Gaia, LS8, Tycho2, or 2MASS source.
-
-    """
-
-    name = 'ops_sky_boss'
-    cadence = None
-    category = 'ops_sky'
-    program = 'SKY'
-    mapper = None
-    priority = 5000
-
-    load_magnitudes = False
-
-    def build_query(self, version_id, query_region):
-
-        min_separation = 10 + ((12. - Skies_v1.mag_neighbour_gaia) / 0.2)
-
-        query = (Skies_v1
-                 .select(CatalogToSkies_v1.catalogid,
-                         Skies_v1.ra,
-                         Skies_v1.dec,
-                         Skies_v1.pix_32768,
-                         Skies_v1.tile_32)
-                 .join(CatalogToSkies_v1)
-                 .where(Skies_v1.sep_neighbour_gaia > min_separation)
-                 .where(CatalogToSkies_v1.version_id == version_id,
-                        CatalogToSkies_v1.best >> True)
-                 .where(Skies_v1.gaia_sky >> True,
-                        Skies_v1.ls8_sky >> True,
-                        Skies_v1.tmass_sky >> True,
-                        Skies_v1.tycho2_sky >> True,
-                        Skies_v1.tmass_xsc_sky >> True))
-
-        if query_region:
-            query = (query
-                     .where(peewee.fn.q3c_radial_query(Skies_v1.ra,
-                                                       Skies_v1.dec,
-                                                       query_region[0],
-                                                       query_region[1],
-                                                       query_region[2])))
-
-        return query
+# class OPS_BOSS_Sky_Carton(BaseCarton):
+#     """Skies for the BOSS spectrograph.
+#
+#     Definition:
+#         Select sky positions from catalogdb.skies_v1 that don't have a
+#         nearby Gaia, LS8, Tycho2, or 2MASS source.
+#
+#     """
+#
+#     name = 'ops_sky_boss'
+#     cadence = None
+#     category = 'ops_sky'
+#     program = 'SKY'
+#     mapper = None
+#     priority = 5000
+#
+#     load_magnitudes = False
+#
+#     def build_query(self, version_id, query_region):
+#
+#         min_separation = 10 + ((12. - Skies_v1.mag_neighbour_gaia) / 0.2)
+#
+#         query = (Skies_v1
+#                  .select(CatalogToSkies_v1.catalogid,
+#                          Skies_v1.ra,
+#                          Skies_v1.dec,
+#                          Skies_v1.pix_32768,
+#                          Skies_v1.tile_32)
+#                  .join(CatalogToSkies_v1)
+#                  .where(Skies_v1.sep_neighbour_gaia > min_separation)
+#                  .where(CatalogToSkies_v1.version_id == version_id,
+#                         CatalogToSkies_v1.best >> True)
+#                  .where(Skies_v1.gaia_sky >> True,
+#                         Skies_v1.ls8_sky >> True,
+#                         Skies_v1.tmass_sky >> True,
+#                         Skies_v1.tycho2_sky >> True,
+#                         Skies_v1.tmass_xsc_sky >> True))
+#
+#         if query_region:
+#             query = (query
+#                      .where(peewee.fn.q3c_radial_query(Skies_v1.ra,
+#                                                        Skies_v1.dec,
+#                                                        query_region[0],
+#                                                        query_region[1],
+#                                                        query_region[2])))
+#
+#         return query
 
 
 class OPS_APOGEE_Sky_Carton(BaseCarton):
@@ -98,6 +101,149 @@ class OPS_APOGEE_Sky_Carton(BaseCarton):
             query = (query
                      .where(peewee.fn.q3c_radial_query(Skies_v1.ra,
                                                        Skies_v1.dec,
+                                                       query_region[0],
+                                                       query_region[1],
+                                                       query_region[2])))
+
+        return query
+
+
+class OPS_Sky_Boss_Best_Carton(BaseCarton):
+    """Top quality skies for the BOSS spectrograph.
+
+    Definition:
+        Select sky positions from catalogdb.skies_v2 that don't have a
+        nearby Gaia, Tycho2, or 2MASS source and that are
+        valid in either lsdr8 or ps1dr2.
+        Take care near edges of ls8 and ps1dr2 footprints
+
+    """
+
+    name = 'ops_sky_boss_best'
+    cadence = None
+    category = 'ops_sky'
+    program = 'SKY'
+    mapper = None
+    instrument = 'BOSS'
+    inertial = True
+    priority = 5000
+
+    load_magnitudes = False
+
+    def build_query(self, version_id, query_region=None):
+        pars = self.parameters
+        # min_separation = 10 + ((12. - Skies_v2.mag_neighbour_gaia) / 0.2)
+
+        query = (
+            Skies_v2
+            .select(
+                CatalogToSkies_v2.catalogid,
+                Skies_v2.ra,
+                Skies_v2.dec,
+                # Skies_v2.pix_32768,  # extra
+                # Skies_v2.tile_32,  # extra
+                # Skies_v2.sep_neighbour_gaia,  # extra
+                # Skies_v2.mag_neighbour_gaia,  # extra
+                # Skies_v2.valid_ls8,  # extra
+                # Skies_v2.sep_neighbour_ls8,  # extra
+                # Skies_v2.mag_neighbour_ls8,  # extra
+                # Skies_v2.valid_ps1dr2,  # extra
+                # Skies_v2.sep_neighbour_ps1dr2,  # extra
+                # Skies_v2.mag_neighbour_ps1dr2,  # extra
+                # min_separation.alias("min_separation_gaia_lim")  # extra
+            )
+            .join(CatalogToSkies_v2)
+            # .where(Skies_v2.sep_neighbour_gaia > min_separation)
+            # .where(Skies_v2.tile_32 >= 6000,
+            #        Skies_v2.tile_32 <= 7000)
+            .where(CatalogToSkies_v2.version_id == version_id,
+                   CatalogToSkies_v2.best >> True)
+            .where(Skies_v2.valid_gaia >> True,
+                   Skies_v2.valid_tmass >> True,
+                   Skies_v2.valid_tycho2 >> True,
+                   Skies_v2.valid_tmass_xsc >> True)
+            .where(
+                fn.COALESCE(Skies_v2.sep_neighbour_ls8, 1e30) > pars['min_sep_ls8'],
+                fn.COALESCE(Skies_v2.sep_neighbour_ps1dr2, 1e30) > pars['min_sep_ps1dr2'],
+                (
+                    (Skies_v2.valid_ls8 >> True) &
+                    (Skies_v2.sep_neighbour_ls8 < pars['max_sep_ls8'])
+                ) |
+                (
+                    (Skies_v2.valid_ps1dr2 >> True) &
+                    (Skies_v2.sep_neighbour_ps1dr2 < pars['max_sep_ps1dr2'])
+                )
+            )
+        )
+
+        if query_region:
+            query = (query
+                     .where(peewee.fn.q3c_radial_query(Skies_v2.ra,
+                                                       Skies_v2.dec,
+                                                       query_region[0],
+                                                       query_region[1],
+                                                       query_region[2])))
+
+        return query
+
+
+class OPS_Sky_Boss_Fallback_Carton(BaseCarton):
+    """Fallback quality skies for the BOSS spectrograph.
+
+    Definition:
+        Select sky positions from catalogdb.skies_v2 that don't have a
+        nearby Gaia, Tycho2, or 2MASS source
+
+    """
+
+    name = 'ops_sky_boss_fallback'
+    cadence = None
+    category = 'ops_sky'
+    program = 'SKY'
+    mapper = None
+    instrument = 'BOSS'
+    inertial = True
+    priority = 5001
+
+    load_magnitudes = False
+
+    def build_query(self, version_id, query_region=None):
+        min_separation = 10 + ((12. - Skies_v2.mag_neighbour_gaia) / 0.2)
+
+        query = (
+            Skies_v2
+            .select(
+                CatalogToSkies_v2.catalogid,
+                Skies_v2.ra,
+                Skies_v2.dec,
+                # Skies_v2.pix_32768,  # extra
+                # Skies_v2.tile_32,  # extra
+                Skies_v2.sep_neighbour_gaia,  # extra
+                Skies_v2.mag_neighbour_gaia,  # extra
+                Skies_v2.valid_ls8,  # extra
+                Skies_v2.sep_neighbour_ls8,  # extra
+                Skies_v2.mag_neighbour_ls8,  # extra
+                Skies_v2.valid_ps1dr2,  # extra
+                Skies_v2.sep_neighbour_ps1dr2,  # extra
+                Skies_v2.mag_neighbour_ps1dr2,  # extra
+                min_separation.alias("min_separation_gaia_lim"),  # extra
+            )
+            .join(CatalogToSkies_v2)
+            .where(Skies_v2.tile_32 >= 6000,
+                   Skies_v2.tile_32 <= 7000)
+            # .where(Skies_v2.sep_neighbour_gaia > min_separation)
+            .where(CatalogToSkies_v2.version_id == version_id,
+                   CatalogToSkies_v2.best >> True)
+            .where(Skies_v2.valid_gaia >> True,
+                   Skies_v2.valid_tmass >> True,
+                   Skies_v2.valid_tycho2 >> True,
+                   Skies_v2.valid_tmass_xsc >> True)
+        )
+
+        if query_region:
+            query = (query
+                     .where(peewee.fn.q3c_radial_query(Skies_v2.ra,
+                                                       Skies_v2.dec,
                                                        query_region[0],
                                                        query_region[1],
                                                        query_region[2])))

--- a/python/target_selection/cartons/ops_skies.py
+++ b/python/target_selection/cartons/ops_skies.py
@@ -13,6 +13,7 @@ from sdssdb.peewee.sdss5db.catalogdb import CatalogToSkies_v2, Skies_v2
 
 from target_selection.cartons.base import BaseCarton
 
+
 # ############################################
 # ############################################
 # ############################################

--- a/python/target_selection/config/target_selection.yml
+++ b/python/target_selection/config/target_selection.yml
@@ -2,7 +2,7 @@
  xmatch_plan: 0.5.0
  cartons:
    - ops_sky_boss_best
-   - ops_sky_boss_fallback
+   - ops_sky_boss_good
  open_fiber_path: /uufs/chpc.utah.edu/common/home/sdss50/sdsswork/target/open_fiber/0.5.0/draft_Sept6/
  schema: sandbox
  magnitudes:
@@ -18,7 +18,7 @@
       max_sep_ps1dr2: 60.0
       min_sep_ls8: 5.0
       min_sep_ps1dr2: 5.0
-    ops_sky_boss_fallback:
+    ops_sky_boss_good:
       min_sep_gaia: 5.0
 
 '0.5.6':

--- a/python/target_selection/config/target_selection.yml
+++ b/python/target_selection/config/target_selection.yml
@@ -1,3 +1,24 @@
+'0.5.7':
+ xmatch_plan: 0.5.0
+ cartons:
+   - ops_sky_boss_best
+   - ops_sky_boss_fallback
+ open_fiber_path: /uufs/chpc.utah.edu/common/home/sdss50/sdsswork/target/open_fiber/0.5.0/draft_Sept6/
+ schema: sandbox
+ magnitudes:
+   h: [catalog_to_tic_v8, tic_v8, twomass_psc.h_m]
+   j: [catalog_to_tic_v8, tic_v8, twomass_psc.j_m]
+   k: [catalog_to_tic_v8, tic_v8, twomass_psc.k_m]
+   bp: [catalog_to_tic_v8, tic_v8, gaia_dr2_source.phot_bp_mean_mag]
+   rp: [catalog_to_tic_v8, tic_v8, gaia_dr2_source.phot_rp_mean_mag]
+   gaia_g: [catalog_to_tic_v8, tic_v8, gaia_dr2_source.phot_g_mean_mag]
+ parameters:
+    ops_sky_boss_best:
+      max_sep_ls8: 60.0
+      max_sep_ps1dr2: 60.0
+      min_sep_ls8: 5.0
+      min_sep_ps1dr2: 5.0
+
 '0.5.6':
  xmatch_plan: 0.5.0
  cartons:

--- a/python/target_selection/config/target_selection.yml
+++ b/python/target_selection/config/target_selection.yml
@@ -18,6 +18,8 @@
       max_sep_ps1dr2: 60.0
       min_sep_ls8: 5.0
       min_sep_ps1dr2: 5.0
+    ops_sky_boss_fallback:
+      min_sep_gaia: 5.0
 
 '0.5.6':
  xmatch_plan: 0.5.0


### PR DESCRIPTION
I have now coded up and spot-checked two new BOSS skies cartons
ops_sky_boss_best
ops_sky_boss_good
I have removed the old obs_sky_boss and ops_sky_apogee cartons from python/target_selection/cartons/ops_skies.py

I have also included a sketch of the logic for one more:
ops_sky_boss_fallback

These are associated with version '0.5.7' in python/target_selection/config/target_selection.yml