### PR TITLE
Update base.py

### DIFF
--- a/python/target_selection/cartons/base.py
+++ b/python/target_selection/cartons/base.py
@@ -417,12 +417,19 @@ class BaseCarton(metaclass=abc.ABCMeta):
                  cdb.Gaia_dr3_synthetic_photometry_gspc.g_sdss_mag.is_null(False),
                  cdb.Gaia_dr3_synthetic_photometry_gspc.r_sdss_mag.is_null(False),
                  cdb.Gaia_dr3_synthetic_photometry_gspc.i_sdss_mag.is_null(False),
-                 cdb.Gaia_dr3_synthetic_photometry_gspc.g_sdss_flag == 1,
-                 cdb.Gaia_dr3_synthetic_photometry_gspc.r_sdss_flag == 1,
-                 cdb.Gaia_dr3_synthetic_photometry_gspc.i_sdss_flag == 1,
-                 # arbitrary faint cut, could go fainter, could cut on G,BP,RP etc instead
+                 # Now removing the flag selection because it killed everything 
+                 # with r_sdss_mag < 14.2
+                 # cdb.Gaia_dr3_synthetic_photometry_gspc.g_sdss_flag == 1,
+                 # cdb.Gaia_dr3_synthetic_photometry_gspc.r_sdss_flag == 1,
+                 # cdb.Gaia_dr3_synthetic_photometry_gspc.i_sdss_flag == 1,
+                 # It's possible that in future, we might want to apply cuts on bp-rp
+                 # or on the derived sdss colours
+                 # Fairly arbitrary faint cut 
                  cdb.Gaia_dr3_synthetic_photometry_gspc.r_sdss_mag < 15.0,
-                 # the following cut on SNR is completely unnecessary at G<15
+                 # Could potentially go fainter, or could cut on G,BP,RP etc instead
+                 # but that would require a join to gaia_dr3_source table
+                 #
+                 # The following cut on SNR is completely unnecessary at G<15
                  # (cdb.Gaia_dr3_synthetic_photometry_gspc.r_sdss_flux_error <
                  #  cdb.Gaia_dr3_synthetic_photometry_gspc.r_sdss_flux / 30.0),
              )

--- a/python/target_selection/cartons/base.py
+++ b/python/target_selection/cartons/base.py
@@ -417,14 +417,14 @@ class BaseCarton(metaclass=abc.ABCMeta):
                  cdb.Gaia_dr3_synthetic_photometry_gspc.g_sdss_mag.is_null(False),
                  cdb.Gaia_dr3_synthetic_photometry_gspc.r_sdss_mag.is_null(False),
                  cdb.Gaia_dr3_synthetic_photometry_gspc.i_sdss_mag.is_null(False),
-                 # Now removing the flag selection because it killed everything 
+                 # Now removing the flag selection because it killed everything
                  # with r_sdss_mag < 14.2
                  # cdb.Gaia_dr3_synthetic_photometry_gspc.g_sdss_flag == 1,
                  # cdb.Gaia_dr3_synthetic_photometry_gspc.r_sdss_flag == 1,
                  # cdb.Gaia_dr3_synthetic_photometry_gspc.i_sdss_flag == 1,
                  # It's possible that in future, we might want to apply cuts on bp-rp
                  # or on the derived sdss colours
-                 # Fairly arbitrary faint cut 
+                 # Fairly arbitrary faint cut
                  cdb.Gaia_dr3_synthetic_photometry_gspc.r_sdss_mag < 15.0,
                  # Could potentially go fainter, or could cut on G,BP,RP etc instead
                  # but that would require a join to gaia_dr3_source table


### PR DESCRIPTION
Removed some overly-strict quality filtering criteria that were preventing  photometry from Gaia_dr3_synthetic_photometry_gspc being attached to targets brighter than about r ~ 14.2 - which was defeating the entire purpose of adding in the Gaia DR3 XP synthetic photometry!